### PR TITLE
[Fix] Modify the `pymdownx.betterem` to enbale bold syntax.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,8 +103,8 @@ markdown_extensions:
       permalink: true
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.betterem:
-      smart_enable: all
+  # https://facelessuser.github.io/pymdown-extensions/extensions/betterem/
+  - pymdownx.betterem
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji


### PR DESCRIPTION
## Description
The original website can't render markdown bold syntax correctly. I found that removing the `smart_enable: all` fixes the issue #3.

## Checklist
Please feel free to remove inapplicable items for your PR.

- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] The PR is complete and small, read the [Google eng practice (CL equals to PR)](https://google.github.io/eng-practices/review/developer/small-cls.html) to understand more about small PR. In DGL, we consider PRs with less than 200 lines of core code change are small (example, test and documentation could be exempted).
- [x] Code is well-documented.
- [x] Related issue is referred in this PR

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->