### PR TITLE
Add ManifoldBT to Python 交易与回测

### DIFF
--- a/docs/library/overview.md
+++ b/docs/library/overview.md
@@ -131,6 +131,8 @@
 
 - Backtrader: Python回测框架
 - Zipline: 量化回测框架
+- vectorbt: 向量化回测框架
+- ManifoldBT: 基于 Rust 核心的高性能 Python 回测引擎（https://github.com/manifoldbt/manifoldbt）
 - Quantopian: 在线量化平台
 - vnpy: Python量化交易平台
 - QUANTAXIS: 量化金融框架

--- a/docs/repo/quant_repo.md
+++ b/docs/repo/quant_repo.md
@@ -171,6 +171,7 @@
 - [qf-lib](https://github.com/quarkfin/qf-lib) - 提供高质量工具用于定量金融分析，涵盖交易策略、回测等功能。
 - [tda-api](https://github.com/alexgolec/tda-api) - 用于获取美股实时/历史行情及下单交易的 TDAmeritrade Python 客户端。
 - [vectorbt](https://github.com/polakowo/vectorbt) - 用于回测、算法交易与研究的强大工具包。
+- [ManifoldBT](https://github.com/manifoldbt/manifoldbt) - 基于 Rust 核心的高性能 Python 回测引擎：向量化信号表达式、真实成交（费用/滑点/前视偏差）、参数扫描、滚动窗口与蒙特卡洛。
 - [Lean](https://github.com/QuantConnect/Lean) - QuantConnect 出品的开源 .NET/Mono/Python 算法交易引擎。
 - [fast-trade](https://github.com/jrmeier/fast-trade) - 低代码回测库，基于 pandas 与技术指标。
 - [pysystemtrade](https://github.com/robcarver17/pysystemtrade) - Robert Carver 开源的回测交易引擎，实现了其在《Systematic Trading》一书中阐述的策略框架，并在其[博客](https://qoppac.blogspot.com/)上进一步拓展。


### PR DESCRIPTION
在两处加入 ManifoldBT（紧邻 vectorbt）：

1. `docs/repo/quant_repo.md` — Python → **交易与回测**（vectorbt 之后）
2. `docs/library/overview.md` — **回测框架**（一并补上 vectorbt + ManifoldBT）

- Rust 核心 + Python API（`pip install manifoldbt`）
- 向量化信号表达式 + 真实成交建模（费用 / 滑点 / 前视偏差）
- 参数扫描、滚动窗口（walk-forward）、蒙特卡洛
- 文档与示例：https://www.manifoldbt.com

非归档项目，列表中无重复项。